### PR TITLE
Add handlers for non image filetype

### DIFF
--- a/assets/scripts/templates/ImageIndexAll.handlebars
+++ b/assets/scripts/templates/ImageIndexAll.handlebars
@@ -9,7 +9,7 @@
                     <div class="thumbnail">
                         <!-- pic display -->
                         <div class="pic-display">
-                              <img src= {{upload.url}} alt='' id="picz">
+                              {{#fileType upload}} {{/fileType}}
                         </div>
                         <!-- pic delete button -->
                         <div class="pic-del-button">

--- a/assets/scripts/templates/helpers/fileType.js
+++ b/assets/scripts/templates/helpers/fileType.js
@@ -1,0 +1,22 @@
+const fileType = function (upload, options) {
+
+  const fileTypes = {
+    pdf: 'http://resources.snappii.com/wp-content/uploads/2015/02/pdf-icon.png',
+    generic: 'https://cdn.fileinfo.com/img/fv/file_viewer_android.png'
+  }
+
+  if (upload.file_type) {
+    if (upload.file_type.split('/').indexOf('image') > -1) {
+      return '<img class="picz" src=' + upload.url + '>'
+    } else {
+      const file = upload.file_type.split('/')[1]
+      if (fileTypes[file]) {
+        return '<img class="picz" src=' + fileTypes[file] + '>'
+      } else {
+        return '<img class="picz" src=' + fileTypes['generic'] + '>'
+      }
+    }
+  }
+}
+
+module.exports = fileType

--- a/assets/scripts/templates/pageShow.handlebars
+++ b/assets/scripts/templates/pageShow.handlebars
@@ -7,7 +7,7 @@
                     <div class="thumbnail">
                         <!-- pic display -->
                         <div class="pics-display">
-                              <img src= {{upload.url}} alt='' id="pict">
+                              {{#fileType upload}} {{/fileType}}
                         </div>
                     </div>
                 </div>

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -23,14 +23,7 @@ p {
 }
 
 // picture in indexAll buttons
-#picz {
-  height: 150px;
-  display: block;
-  margin: auto;
-}
-
-// show pics no buttons
-#pict {
+.picz {
   height: 150px;
   display: block;
   margin: auto;


### PR DESCRIPTION
1. Add custom handlebars handler which accepts an upload an image with
the source equal to either:
  a. the aws url if it's an image
  b. a generic pdf image url if it's a pdf
  c. a generic file image url if it's neither a pdf nor an image.

2. Add custom handlebars template tag to both IndexAll handlebars file
and pageShow handlebars files where the img used to be.